### PR TITLE
Improve My Cards builder usability and mobile flow

### DIFF
--- a/mycards.html
+++ b/mycards.html
@@ -109,6 +109,17 @@
         .btn-secondary:hover:not(:disabled) { background: #e2e8f0; }
         .btn-danger { background: #fee2e2; color: #dc2626; border: 1px solid #fecaca; }
         .btn-danger:hover:not(:disabled) { background: #fecaca; }
+        .btn:focus-visible,
+        .tab-btn:focus-visible,
+        .align-btn:focus-visible,
+        .row-move:focus-visible,
+        .row-remove:focus-visible,
+        .row-chip-move:focus-visible,
+        .row-chip-remove:focus-visible,
+        .live-card-nav button:focus-visible {
+            outline: 3px solid rgba(99,102,241,.25);
+            outline-offset: 2px;
+        }
 
         /* ── Tabs ── */
         .tab-bar {
@@ -165,6 +176,44 @@
             letter-spacing: .08em;
             color: #94a3b8;
             margin-bottom: 14px;
+        }
+        .intro-card {
+            background: linear-gradient(135deg, #eef2ff 0%, #fff 58%, #f0fdf4 100%);
+            border: 1px solid #dbeafe;
+            border-radius: 16px;
+            padding: 16px 18px;
+            margin-bottom: 16px;
+            box-shadow: 0 10px 30px rgba(99,102,241,.08);
+        }
+        .intro-title { font-size: 16px; font-weight: 800; color: #0f172a; margin-bottom: 6px; }
+        .intro-copy { font-size: 13px; line-height: 1.55; color: #475569; max-width: 70ch; }
+        .flow-steps {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 8px;
+            margin-top: 14px;
+        }
+        .flow-step {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 9px 10px;
+            background: rgba(255,255,255,.78);
+            border: 1px solid rgba(199,210,254,.7);
+            border-radius: 12px;
+            font-size: 11px;
+            font-weight: 700;
+            color: #475569;
+        }
+        .flow-step span:first-child {
+            display: grid;
+            place-items: center;
+            width: 22px;
+            height: 22px;
+            border-radius: 999px;
+            background: #6366f1;
+            color: #fff;
+            flex-shrink: 0;
         }
 
         /* ── Form Controls ── */
@@ -356,6 +405,32 @@
             overflow-x: hidden;
         }
 
+        .builder-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            margin-bottom: 8px;
+        }
+        .builder-toolbar .section-title { margin-bottom: 0; padding: 0; }
+        .quick-add {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            margin-left: auto;
+        }
+        .quick-add .form-select { min-width: 160px; }
+        .mobile-builder-tip {
+            display: none;
+            margin: 0 0 10px;
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            color: #64748b;
+            font-size: 12px;
+            line-height: 1.45;
+        }
         .layout-editor {
             background: #fff;
             border: 1px solid #e2e8f0;
@@ -363,11 +438,12 @@
             overflow: hidden;
             min-height: 120px;
         }
+        .layout-editor.drag-over { border-color: #818cf8; box-shadow: 0 0 0 3px rgba(99,102,241,.08); }
         .layout-row {
             display: flex;
             align-items: center;
             gap: 10px;
-            padding: 10px 12px;
+            padding: 12px;
             border-bottom: 1px solid #f1f5f9;
             background: #fff;
             transition: background .15s;
@@ -379,9 +455,10 @@
         .layout-row.drag-over { background: #eef2ff; }
         .layout-row:active { cursor: grabbing; }
         .layout-row-inner {
-            display: flex;
+            display: grid;
+            grid-template-columns: auto auto minmax(0, 1fr) auto auto auto auto;
             align-items: center;
-            gap: 10px;
+            gap: 8px;
             flex: 1;
             min-width: 0;
         }
@@ -462,8 +539,8 @@
         .row-chip-move:hover,
         .row-chip-remove:hover { background: #a5b4fc; }
         .row-add-select {
-            max-width: 150px;
-            min-width: 120px;
+            max-width: 170px;
+            min-width: 128px;
             padding: 5px 8px;
             border: 1px solid #e2e8f0;
             border-radius: 6px;
@@ -478,8 +555,8 @@
             flex-shrink: 0;
         }
         .align-btn {
-            width: 28px;
-            height: 28px;
+            width: 32px;
+            height: 32px;
             border: 1px solid #e2e8f0;
             background: #f8fafc;
             border-radius: 6px;
@@ -495,8 +572,8 @@
         .align-btn:hover { background: #eef2ff; border-color: #c7d2fe; }
         .align-btn.active { background: #6366f1; color: #fff; border-color: #6366f1; }
         .row-remove {
-            width: 28px;
-            height: 28px;
+            width: 32px;
+            height: 32px;
             border-radius: 6px;
             background: #fee2e2;
             color: #dc2626;
@@ -511,8 +588,8 @@
         }
         .row-remove:hover { background: #fecaca; }
         .row-move {
-            width: 28px;
-            height: 28px;
+            width: 32px;
+            height: 32px;
             border-radius: 6px;
             background: #f8fafc;
             color: #475569;
@@ -529,7 +606,9 @@
         .layout-actions {
             display: flex;
             justify-content: center;
+            gap: 8px;
             margin-top: 10px;
+            padding: 0 2px;
         }
 
         .palette-section {
@@ -548,6 +627,7 @@
             border-radius: 8px;
             background: #f8fafc;
             border: 1.5px solid #e2e8f0;
+            font-family: inherit;
             font-size: 11px;
             font-weight: 600;
             color: #64748b;
@@ -573,6 +653,7 @@
             border: 1px solid #e2e8f0;
             border-radius: 12px;
             padding: 16px;
+            position: sticky;
             top: 0;
         }
         .live-card-header {
@@ -754,12 +835,51 @@
         /* ══════════════════════════════════════
            RESPONSIVE
            ══════════════════════════════════════ */
-        @media (max-width: 600px) {
-            .header { padding: 10px 12px; gap: 8px; }
-            .header-title { font-size: 13px; }
-            .view-scroll { padding: 12px; }
-            .form-grid { grid-template-columns: 1fr; }
-            .design-card-frame { width: 2in; height: 2.8in; }
+        @media (max-width: 760px) {
+            html, body { overflow: auto; }
+            #app { min-height: 100dvh; height: auto; }
+            .header { padding: 10px 12px; gap: 8px; flex-wrap: wrap; }
+            .header-title { font-size: 14px; width: 100%; }
+            .header-input { flex-basis: calc(100% - 88px); min-height: 42px; font-size: 16px; }
+            .header .btn { min-height: 42px; justify-content: center; }
+            .badge.visible { order: 4; width: 100%; text-align: center; margin-top: -2px; }
+            .tab-bar { padding: 0 8px; position: sticky; top: 0; z-index: 20; }
+            .tab-btn { padding: 12px 8px; font-size: 11px; min-height: 46px; }
+            .view { overflow: visible; }
+            .view-scroll { padding: 12px; overflow: visible; }
+            .section { padding: 14px; border-radius: 14px; }
+            .form-grid { grid-template-columns: 1fr; gap: 10px; }
+            .form-select, .form-input { min-height: 42px; font-size: 16px; }
+            .toggle-row { padding: 13px 0; }
+            .toggle-wrap { width: 48px; height: 28px; }
+            .toggle-slider { border-radius: 28px; }
+            .toggle-slider::before { width: 22px; height: 22px; }
+            .toggle-wrap input:checked + .toggle-slider::before { transform: translateX(20px); }
+            .flow-steps { grid-template-columns: 1fr; }
+            .design-container { gap: 12px; }
+            .design-right { order: -1; overflow: visible; }
+            .design-left { overflow: visible; }
+            .live-card-wrapper { position: static; }
+            .live-card-frame { max-width: min(260px, 82vw); }
+            .builder-toolbar { align-items: stretch; flex-direction: column; }
+            .quick-add { margin-left: 0; width: 100%; }
+            .quick-add .form-select { min-width: 0; flex: 1; }
+            .mobile-builder-tip { display: block; }
+            .layout-row { align-items: stretch; }
+            .layout-row-inner { grid-template-columns: auto auto 1fr; align-items: start; }
+            .row-elements { grid-column: 1 / -1; order: 3; }
+            .row-align { grid-column: 1 / -1; order: 4; }
+            .row-align .align-btn { flex: 1; min-height: 40px; }
+            .row-move, .row-remove { min-width: 42px; min-height: 42px; }
+            .row-move[data-dir="up"] { grid-column: 1; order: 5; width: 100%; }
+            .row-move[data-dir="down"] { grid-column: 2; order: 5; width: 100%; }
+            .row-remove { grid-column: 3; order: 5; width: 100%; }
+            .row-add-select { min-width: 100%; max-width: none; min-height: 38px; }
+            .palette-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            .palette-chip { min-height: 58px; cursor: pointer; }
+            .toast { left: 12px; right: 12px; top: auto; bottom: 12px; max-width: none; }
+            .modal-overlay { padding: 12px; align-items: flex-end; }
+            .modal-box { max-height: 86dvh; padding: 18px; border-radius: 16px 16px 0 0; }
         }
     </style>
 </head>
@@ -801,6 +921,16 @@
              ════════════════════════════════════ -->
         <div id="settingsView" class="view active" role="tabpanel">
             <div class="view-scroll">
+
+                <div class="intro-card">
+                    <div class="intro-title">Build a printable custom deck from your BGG collection</div>
+                    <div class="intro-copy">Start with print settings and filters, arrange the card fields in Design, then preview the exact pages before printing or cutting.</div>
+                    <div class="flow-steps" aria-label="Card builder workflow">
+                        <div class="flow-step"><span>1</span> Load collection</div>
+                        <div class="flow-step"><span>2</span> Tune layout</div>
+                        <div class="flow-step"><span>3</span> Preview &amp; print</div>
+                    </div>
+                </div>
 
                 <!-- Card Configuration -->
                 <div class="section">
@@ -922,7 +1052,14 @@
                     <!-- LEFT: Layout Builder -->
                     <div class="design-left">
                         <div>
-                            <div class="section-title" style="padding:0 0 8px;">Card Layout (One Line Per Element)</div>
+                            <div class="builder-toolbar">
+                                <div class="section-title">Card Layout</div>
+                                <div class="quick-add" aria-label="Add a card element as a new row">
+                                    <select id="quickAddSelect" class="form-select"></select>
+                                    <button class="btn btn-primary" id="quickAddBtn" type="button">+ Add</button>
+                                </div>
+                            </div>
+                            <div class="mobile-builder-tip"><strong>Mobile tip:</strong> tap an element below to add it, then use ↑/↓ and L/C/R controls to tune the card.</div>
                             <div class="layout-editor" id="layoutEditor"></div>
                         </div>
 
@@ -939,9 +1076,9 @@
 
                         <div style="background:#f9fafb;border:1px solid #e2e8f0;border-radius:8px;padding:12px;font-size:11px;color:#64748b;line-height:1.6;">
                             <strong style="color:#334155;">How it works:</strong><br>
-                            Drag elements from the palette to add them to your layout. Each element appears as one line on the card.<br><br>
-                            <strong>Alignment</strong> — Click L/C/R to align each line left, center, or right.<br><br>
-                            Order matters — drag rows to reorder. Your real game data shows in the preview on the right.
+                            Drag elements from the palette or use the Add control to place each element as its own row on the card.<br><br>
+                            <strong>Combine fields</strong> — Use “Add to row…” to place small facts on one line, such as players + time + weight.<br><br>
+                            <strong>Alignment</strong> — Click L/C/R to align each row. Use ↑/↓ for reliable reordering on touch screens.
                         </div>
                     </div>
 
@@ -1752,13 +1889,40 @@
         renderLiveCard();
     }
 
-    function addRow(elementKey = 'name') {
-        if (!CARD_ELEMENTS[elementKey]) return;
-        cardLayout.push({ elements: [elementKey], align: 'center' });
+    function getUsedElementKeys() {
+        return new Set(cardLayout.flatMap(row => row.elements || []));
+    }
+
+    function getUnusedElementKeys() {
+        const used = getUsedElementKeys();
+        return CARD_ELEMENT_KEYS.filter(key => !used.has(key));
+    }
+
+    function updateQuickAddSelect() {
+        const select = $('quickAddSelect');
+        const btn = $('quickAddBtn');
+        if (!select || !btn) return;
+        const unused = getUnusedElementKeys();
+        select.innerHTML = unused.length
+            ? unused.map(key => `<option value="${key}">${CARD_ELEMENTS[key].icon} ${CARD_ELEMENTS[key].label}</option>`).join('')
+            : '<option value="">All elements added</option>';
+        select.disabled = unused.length === 0;
+        btn.disabled = unused.length === 0;
+    }
+
+    function addRow(elementKey = '') {
+        const key = elementKey || getUnusedElementKeys()[0];
+        if (!CARD_ELEMENTS[key]) return;
+        if (getUsedElementKeys().has(key)) {
+            showToast(`${CARD_ELEMENTS[key].label} is already in the layout`, 'warn');
+            return;
+        }
+        cardLayout.push({ elements: [key], align: 'center' });
         saveLayout();
         buildLayoutEditor();
         buildPalette();
         renderLiveCard();
+        showToast(`Added ${CARD_ELEMENTS[key].label}`, 'success', 1800);
     }
 
     function addElementToRow(rowIdx, elementKey) {
@@ -1934,8 +2098,10 @@
         const editor = $('layoutEditor');
         if (!editor) return;
 
+        updateQuickAddSelect();
+
         if (!cardLayout.length) {
-            editor.innerHTML = '<div class="layout-row no-items">No rows yet. Add a row or drag an element into the layout.</div>';
+            editor.innerHTML = '<div class="layout-row no-items">No rows yet. Use + Add, tap an element, or drag one here.</div>';
             return;
         }
 
@@ -1967,7 +2133,8 @@
             </div>`;
         }).join('');
 
-        editor.insertAdjacentHTML('beforeend', `<div class="layout-actions"><button class="btn" id="addRowBtn" type="button">+ Add Row</button></div>`);
+        editor.insertAdjacentHTML('beforeend', `<div class="layout-actions"><button class="btn btn-secondary" id="addRowBtn" type="button">+ Add next unused element</button></div>`);
+        updateQuickAddSelect();
 
         // Wire up alignment buttons
         editor.querySelectorAll('.align-btn').forEach(btn => {
@@ -2027,7 +2194,7 @@
             });
         });
 
-        $('addRowBtn').addEventListener('click', () => addRow('name'));
+        $('addRowBtn').addEventListener('click', () => addRow());
 
         // Wire up drag & drop for row reordering
         editor.querySelectorAll('.layout-row').forEach((row, idx) => {
@@ -2053,16 +2220,18 @@
     function buildPalette() {
         const palette = $('designPalette');
         if (!palette) return;
-        const used = new Set(cardLayout.flatMap(row => row.elements || []));
+        const used = getUsedElementKeys();
         palette.innerHTML = Object.entries(CARD_ELEMENTS).map(([key, el]) => {
             const isUsed = used.has(key);
-            return `<div class="palette-chip ${isUsed ? 'used' : ''}" draggable="${!isUsed}" data-elem="${key}">
+            const title = isUsed ? `${el.label} is already in your layout` : `Add ${el.label} to the card`;
+            return `<button type="button" class="palette-chip ${isUsed ? 'used' : ''}" draggable="${!isUsed}" data-elem="${key}" title="${title}" ${isUsed ? 'disabled' : ''}>
                 <span>${el.icon}</span>
                 <span>${el.label}</span>
-            </div>`;
+            </button>`;
         }).join('');
 
         palette.querySelectorAll('.palette-chip:not(.used)').forEach(chip => {
+            chip.addEventListener('click', () => addRow(chip.dataset.elem));
             chip.addEventListener('dragstart', e => {
                 e.dataTransfer.effectAllowed = 'move';
                 e.dataTransfer.setData('text/plain', chip.dataset.elem);
@@ -2103,6 +2272,8 @@
 
     $('designPrev').addEventListener('click', () => { designPreviewIdx--; renderLiveCard(); });
     $('designNext').addEventListener('click', () => { designPreviewIdx++; renderLiveCard(); });
+
+    $('quickAddBtn').addEventListener('click', () => addRow($('quickAddSelect').value));
 
     $('resetLayoutBtn').addEventListener('click', () => {
         cardLayout = getDefaultCardLayout();


### PR DESCRIPTION
### Motivation
- Make the custom card builder easier to understand and faster to use, especially on mobile and touch devices. 
- Reduce friction when composing card rows and prevent accidental duplicate additions while keeping the live preview visible during edits.

### Description
- Updated `mycards.html` UI and CSS: added an introductory `intro-card` with a 3-step workflow, stronger `:focus-visible` outlines, larger/tappable controls, and responsive rules tuned for small screens.
- Enhanced the layout builder: added a quick-add toolbar and mobile tip, replaced palette items with tappable buttons, improved empty-state copy, and enlarged row action controls and alignment buttons for touch use.
- Added helper functions and logic to manage available elements and quick-add state: `getUsedElementKeys()`, `getUnusedElementKeys()`, and `updateQuickAddSelect()`, and modified `addRow()` to use them and to show toasts on add/duplicate.
- Wire-up and UX changes: `buildLayoutEditor()` and `buildPalette()` now keep controls in sync, palette chips can be tapped to add elements, `addRow`/row-reorder/update flows refresh the editor/palette/preview, and the live preview is sticky on larger screens but prioritized on mobile.

### Testing
- Ran `node --check /tmp/mycards-script.js` to validate embedded script syntax (succeeded).
- Ran `git diff --check` to ensure no whitespace/diff-check issues (succeeded).
- Served the page locally and ran `curl -I http://127.0.0.1:4173/mycards.html` to validate the file is reachable (HTTP 200, succeeded).
- Attempted a mobile screenshot with Playwright (`npx playwright screenshot ...`) but registry access was blocked by the environment (npm returned HTTP 403), so visual screenshot capture could not be completed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00976d958883238c54c8077b450db8)