### PR TITLE
[codex] Refine BGG collection and price controls

### DIFF
--- a/bgg-price-tracker.html
+++ b/bgg-price-tracker.html
@@ -79,6 +79,7 @@
     .source-error { max-width:120px; color:var(--red); overflow:hidden; text-overflow:ellipsis }
     .empty { color:#51677c }
     .row-actions { display:flex; align-items:center; gap:6px }
+    .single-source { width:112px; height:30px; padding:0 7px; font-size:11px }
     .status-dot { display:inline-block; width:7px; height:7px; margin-right:5px; border-radius:50%; background:var(--green) }
     .loading-dot { animation:pulse 1s ease-in-out infinite; background:var(--amber) }
     @keyframes pulse { 50% { opacity:.25 } }
@@ -113,7 +114,7 @@
   </header>
 
   <section class="status-panel" aria-label="BGG collection status filters">
-    <div class="panel-title">Collection filters <span>On statuses are combined as OR; Off exclusions apply to every result; Any ignores that status.</span></div>
+    <div class="panel-title">Display filters <span>The full collection loads once. On statuses combine as OR; Off excludes; Any ignores.</span></div>
     <div class="status-grid">
       <div class="status-control"><label for="status-own">Owned</label><select id="status-own" class="control collection-status" data-param="own"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
       <div class="status-control"><label for="status-wishlist">Wishlist</label><select id="status-wishlist" class="control collection-status" data-param="wishlist"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
@@ -121,7 +122,7 @@
       <div class="status-control"><label for="status-wanttoplay">Want to Play</label><select id="status-wanttoplay" class="control collection-status" data-param="wanttoplay"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
       <div class="status-control"><label for="status-wanttobuy">Want to Buy</label><select id="status-wanttobuy" class="control collection-status" data-param="wanttobuy"><option value="">Any</option><option value="1" selected>On</option><option value="0">Off</option></select></div>
       <div class="status-control"><label for="status-preordered">Preordered</label><select id="status-preordered" class="control collection-status" data-param="preordered"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-trade">For Trade</label><select id="status-trade" class="control collection-status" data-param="trade"><option value="">Any</option><option value="1" selected>On</option><option value="0">Off</option></select></div>
+      <div class="status-control"><label for="status-trade">For Trade</label><select id="status-trade" class="control collection-status" data-param="fortrade"><option value="">Any</option><option value="1" selected>On</option><option value="0">Off</option></select></div>
       <div class="status-control"><label for="status-prevowned">Previously Owned</label><select id="status-prevowned" class="control collection-status" data-param="prevowned"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
     </div>
   </section>
@@ -279,6 +280,13 @@
           year: number(text(item, 'yearpublished')),
           thumbnail: text(item, 'thumbnail'),
           image: text(item, 'image'),
+          statuses: (() => {
+            const status = item.querySelector('status');
+            return Object.fromEntries(
+              ['own','wishlist','want','wanttoplay','wanttobuy','preordered','fortrade','prevowned']
+                .map((name) => [name, status?.getAttribute(name) === '1'])
+            );
+          })(),
           myRating: valueAttr(item, 'stats rating') === -1 ? null : valueAttr(item, 'stats rating'),
           average: valueAttr(item, 'stats rating average'),
           plays: number(text(item, 'numplays')) || 0,
@@ -289,12 +297,12 @@
         })).filter((game) => game.bggId && game.name);
       }
 
-      async function requestCollectionPart(username, statusParams, label) {
-        const params = new URLSearchParams({ endpoint:'collection', username, stats:'1', ...statusParams });
+      async function requestCollection(username) {
+        const params = new URLSearchParams({ endpoint:'collection', username, stats:'1' });
         let lastError;
         for (let attempt = 0; attempt < 4; attempt++) {
           try {
-            setProgress(`Loading collection · ${label}${attempt ? ` · retry ${attempt + 1}/4` : ''}`);
+            setProgress(`Loading full collection${attempt ? ` · retry ${attempt + 1}/4` : ''}`);
             const response = await fetch(`/api/bgg-helper.js?${params}`);
             const body = await response.text();
             if (response.status === 202 || /please try again|queued/i.test(body)) {
@@ -316,38 +324,16 @@
         throw lastError;
       }
 
-      async function requestCollection(username, filters) {
-        const on = Object.entries(filters).filter(([, value]) => value === '1');
-        const off = Object.fromEntries(Object.entries(filters).filter(([, value]) => value === '0'));
-        const jobs = on.length
-          ? on.map(([param]) => ({ params:{ ...off, [param]:'1' }, label:param }))
-          : [{ params:off, label:'all statuses' }];
-        const results = new Array(jobs.length);
-        let cursor = 0;
-        const workers = Array.from({ length:Math.min(2, jobs.length) }, async () => {
-          while (cursor < jobs.length) {
-            const index = cursor++;
-            results[index] = await requestCollectionPart(username, jobs[index].params, jobs[index].label);
-          }
-        });
-        await Promise.all(workers);
-        const unique = new Map();
-        results.flat().forEach((game) => unique.set(game.bggId, game));
-        return [...unique.values()].sort((a, b) => a.name.localeCompare(b.name));
-      }
-
       async function loadCollection(force = false) {
         const username = elements.username.value.trim() || 'sportomax';
-        const filters = collectionFilters();
         elements.username.value = username;
         elements.load.disabled = true;
-        setProgress(`Loading ${username}'s owned games…`);
+        setProgress(`Loading ${username}'s full collection…`);
         try {
-          const filterKey = Object.entries(filters).sort().map(([key, value]) => `${key}:${value}`).join('|') || 'any';
-          const key = `bgg-market:collection:${username.toLowerCase()}:${filterKey}`;
+          const key = `bgg-market:collection:${username.toLowerCase()}:full`;
           let games = force ? null : cacheGet(key, COLLECTION_TTL);
           if (!games) {
-            games = await requestCollection(username, filters);
+            games = await requestCollection(username);
             cacheSet(key, games);
           }
           state.games = games;
@@ -355,7 +341,7 @@
           state.failures = {};
           restorePriceCache(games);
           render();
-          setProgress(`Loaded ${games.length} matching games`, 1, 1);
+          setProgress(`Loaded ${games.length} full-collection games`, 1, 1);
           toast(`${games.length} games loaded for ${username}`);
         } catch (error) {
           setProgress('Collection failed');
@@ -463,8 +449,13 @@
       function filteredGames() {
         const query = elements.search.value.trim().toLowerCase();
         const threshold = number(elements.threshold.value);
+        const filters = collectionFilters();
+        const required = Object.entries(filters).filter(([, value]) => value === '1').map(([name]) => name);
+        const excluded = Object.entries(filters).filter(([, value]) => value === '0').map(([name]) => name);
         return state.games.filter((game) => {
           const price = state.prices[game.bggId];
+          if (required.length && !required.some((name) => game.statuses?.[name])) return false;
+          if (excluded.some((name) => game.statuses?.[name])) return false;
           if (query && !game.name.toLowerCase().includes(query) && !game.bggId.includes(query)) return false;
           if (elements.amazonOnly.checked && price?.amazon?.price == null) return false;
           if (threshold !== null && (price?.bestOverall?.price == null || price.bestOverall.price > threshold)) return false;
@@ -519,11 +510,17 @@
           ? `${linkedPrice(price.bestOverall.price, price.bestOverall.url, price.bestOverall.currency, true)}
              <div class="subline">${escapeHtml(price.bestOverall.source)} · ${escapeHtml(price.bestOverall.label)}</div>`
           : '<span class="empty">—</span>';
-        const status = failed
-          ? `<div class="source-error" title="${escapeHtml(failed)}">Request failed</div>`
-          : loading
-            ? '<span class="muted"><span class="status-dot loading-dot"></span>Checking</span>'
-            : `<button class="btn btn-small" data-refresh="${game.bggId}">Refresh</button>`;
+        const status = loading
+          ? '<span class="muted"><span class="status-dot loading-dot"></span>Checking</span>'
+          : `<select class="control single-source" data-source-for="${game.bggId}" aria-label="Price source for ${escapeHtml(game.name)}">
+               <option value="checked">Checked sources</option>
+               <option value="amazon">Amazon</option>
+               <option value="vendors">Others</option>
+               <option value="ebay">eBay</option>
+               <option value="geekmarket">Marketplace</option>
+             </select>
+             <button class="btn btn-small" data-run-single="${game.bggId}">Run</button>
+             ${failed ? `<div class="source-error" title="${escapeHtml(failed)}">Failed</div>` : ''}`;
         return `<tr>
           <td class="game-cell"><div class="game">${thumb}<div>
             <a class="game-name" href="https://boardgamegeek.com/boardgame/${game.bggId}" target="_blank" rel="noopener">${escapeHtml(game.name)}</a>
@@ -570,11 +567,16 @@
         render();
       }));
       elements.rows.addEventListener('click', (event) => {
-        const button = event.target.closest('[data-refresh]');
-        if (button) priceOne(button.dataset.refresh, elements.forcePrices.checked);
+        const button = event.target.closest('[data-run-single]');
+        if (!button) return;
+        const id = button.dataset.runSingle;
+        const choice = elements.rows.querySelector(`[data-source-for="${id}"]`)?.value || 'checked';
+        const sources = choice === 'checked' ? selectedPriceSources() : [choice];
+        priceOne(id, elements.forcePrices.checked, sources);
       });
       [elements.search, elements.threshold].forEach((input) => input.addEventListener('input', render));
       elements.amazonOnly.addEventListener('change', render);
+      document.querySelectorAll('.collection-status').forEach((select) => select.addEventListener('change', render));
       elements.load.addEventListener('click', () => loadCollection(true));
       elements.username.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') loadCollection(true);


### PR DESCRIPTION
## What changed
- load the complete BGG collection independently of display filters
- apply tri-state collection statuses locally without refetching
- keep pricing manual and limit bulk pricing to visible games
- add per-game source selection for Amazon, other vendors, eBay, or GeekMarket

## Why
This avoids unnecessary collection calls while giving precise control over which games and marketplace sources receive price requests.

## Checks
- inline tracker JavaScript syntax validation
- no automatic collection-load guard
- API module syntax validation