### PR TITLE
[codex] Fix empty BGG table filters

### DIFF
--- a/bgg-price-tracker.html
+++ b/bgg-price-tracker.html
@@ -13,7 +13,7 @@
     }
     * { box-sizing:border-box }
     html { background:var(--bg) }
-    body { height:100vh; margin:0; min-width:1120px; overflow:hidden; display:flex; flex-direction:column; color:var(--text); background:var(--bg); font:14px/1.45 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif }
+    body { height:100vh; margin:0; min-width:1000px; overflow:hidden; display:flex; flex-direction:column; color:var(--text); background:var(--bg); font:14px/1.45 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif }
     button,input,select { font:inherit }
     button { color:inherit }
     a { color:inherit; text-decoration:none }
@@ -36,7 +36,7 @@
     .btn-primary:hover { background:#54df96; border-color:#54df96 }
     .btn-small { height:30px; padding:0 9px; font-size:12px }
     .status-panel { padding:11px 20px 12px; border-bottom:1px solid var(--line); background:#0a1726 }
-    .panel-title { display:flex; align-items:baseline; gap:10px; margin-bottom:8px; font-size:12px; font-weight:800; letter-spacing:.06em; text-transform:uppercase }
+    .panel-title { display:flex; align-items:center; gap:10px; margin-bottom:8px; font-size:12px; font-weight:800; letter-spacing:.06em; text-transform:uppercase }
     .panel-title span { color:var(--muted); font-size:11px; font-weight:500; letter-spacing:0; text-transform:none }
     .status-grid { display:grid; grid-template-columns:repeat(8,minmax(112px,1fr)); gap:8px }
     .status-control { display:flex; align-items:center; gap:7px; min-width:0 }
@@ -46,9 +46,11 @@
     .progress-track { height:4px; flex:1; background:#182c42; border-radius:999px; overflow:hidden }
     .progress-bar { width:0; height:100%; background:var(--green); transition:width .25s ease }
     .progress-label { min-width:210px; color:var(--muted); font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
-    .toolbar { display:flex; align-items:center; gap:10px; padding:14px 20px; overflow-x:auto; border-bottom:1px solid var(--line); background:#091523 }
+    .toolbar { display:flex; align-items:center; flex-wrap:wrap; gap:9px; padding:10px 20px; border-bottom:1px solid var(--line); background:#091523 }
     .toolbar > * { flex:0 0 auto }
     .toolbar > .grow { flex:1 0 20px }
+    .toolbar-label { color:var(--muted); font-size:11px; font-weight:800; letter-spacing:.06em; text-transform:uppercase }
+    .price-toolbar { padding-block:9px; background:#08131f }
     .search { width:250px }
     .threshold { width:105px }
     .check { height:38px; display:flex; align-items:center; gap:8px; padding:0 11px; border:1px solid var(--line); border-radius:9px; color:#c8d5e3; background:#0a1726; white-space:nowrap; cursor:pointer }
@@ -95,6 +97,8 @@
     .debug-form input { flex:1 }
     .toast { position:fixed; right:18px; bottom:18px; z-index:20; max-width:420px; padding:11px 14px; border:1px solid #36516b; border-radius:10px; color:#dce9f6; background:#102238; box-shadow:0 12px 36px #0008; opacity:0; transform:translateY(8px); pointer-events:none; transition:.2s }
     .toast.show { opacity:1; transform:none }
+    .zero-state { display:flex; align-items:center; gap:10px; min-width:420px; padding:8px 0 }
+    .zero-state strong { color:var(--text) }
     @media (max-height:720px) { .topbar { min-height:60px; padding-block:9px } }
   </style>
 </head>
@@ -114,7 +118,13 @@
   </header>
 
   <section class="status-panel" aria-label="BGG collection status filters">
-    <div class="panel-title">Display filters <span>The full collection loads once. On statuses combine as OR; Off excludes; Any ignores.</span></div>
+    <div class="panel-title">
+      Display filters
+      <span>The full collection stays loaded. On statuses combine as OR; Off excludes; Any ignores.</span>
+      <span class="grow"></span>
+      <button id="resetStatuses" class="btn btn-small">Reset defaults</button>
+      <button id="showAllStatuses" class="btn btn-small">Show all statuses</button>
+    </div>
     <div class="status-grid">
       <div class="status-control"><label for="status-own">Owned</label><select id="status-own" class="control collection-status" data-param="own"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
       <div class="status-control"><label for="status-wishlist">Wishlist</label><select id="status-wishlist" class="control collection-status" data-param="wishlist"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
@@ -137,6 +147,13 @@
     <input id="search" class="control search" type="search" placeholder="Search games or BGG ID">
     <label class="check"><input id="amazonOnly" type="checkbox"> Has Amazon price</label>
     <label class="check">Any price under $ <input id="threshold" class="control threshold" type="number" min="0" step="1" placeholder="100"></label>
+    <button id="clearDisplayFilters" class="btn">Clear search/price filters</button>
+    <span class="grow"></span>
+    <span id="visibleHint" class="muted">Load a collection to begin.</span>
+  </section>
+
+  <section class="toolbar price-toolbar" aria-label="Price run controls">
+    <span class="toolbar-label">Price sources</span>
     <label class="check"><input class="price-source" type="checkbox" value="amazon" checked> Amazon</label>
     <label class="check"><input class="price-source" type="checkbox" value="vendors" checked> Others</label>
     <label class="check"><input class="price-source" type="checkbox" value="ebay" checked> eBay</label>
@@ -217,13 +234,18 @@
         gameMetric: $('gameMetric'), pricedMetric: $('pricedMetric'), errorMetric: $('errorMetric'),
         progressLabel: $('progressLabel'), progressBar: $('progressBar'), progressPercent: $('progressPercent'),
         lastChecked: $('lastChecked'), debug: $('debugDialog'), debugId: $('debugId'),
-        debugOutput: $('debugOutput'), toast: $('toast')
+        debugOutput: $('debugOutput'), toast: $('toast'), visibleHint: $('visibleHint')
+      };
+      const STATUS_DEFAULTS = {
+        own:'', wishlist:'', want:'', wanttoplay:'', wanttobuy:'1',
+        preordered:'', fortrade:'1', prevowned:''
       };
 
       const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => ({
         '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
       })[char]);
       const number = (value) => {
+        if (value === null || value === undefined || String(value).trim() === '') return null;
         const parsed = Number(value);
         return Number.isFinite(parsed) ? parsed : null;
       };
@@ -268,6 +290,22 @@
       );
       const selectedPriceSources = () => [...document.querySelectorAll('.price-source:checked')]
         .map((input) => input.value);
+      const setStatusFilters = (values) => {
+        document.querySelectorAll('.collection-status').forEach((select) => {
+          select.value = values[select.dataset.param] ?? '';
+        });
+      };
+      const activeFilterLabel = () => {
+        const labels = {
+          own:'Owned', wishlist:'Wishlist', want:'Want', wanttoplay:'Want to Play',
+          wanttobuy:'Want to Buy', preordered:'Preordered', fortrade:'For Trade',
+          prevowned:'Previously Owned'
+        };
+        const filters = collectionFilters();
+        const on = Object.entries(filters).filter(([, value]) => value === '1').map(([name]) => labels[name]);
+        const off = Object.entries(filters).filter(([, value]) => value === '0').map(([name]) => `not ${labels[name]}`);
+        return [...on, ...off].join(', ') || 'All statuses';
+      };
 
       function parseCollection(xml) {
         const doc = new DOMParser().parseFromString(xml, 'text/xml');
@@ -546,13 +584,20 @@
         const games = filteredGames();
         elements.rows.innerHTML = games.length
           ? games.map(rowHtml).join('')
-          : `<tr><td class="game-cell muted" colspan="25">${state.games.length ? 'No games match these filters.' : 'No collection loaded.'}</td></tr>`;
+          : `<tr><td class="game-cell muted" colspan="25">${
+              state.games.length
+                ? `<div class="zero-state"><strong>No games match the current display filters.</strong><button class="btn btn-small" data-show-all>Show all ${state.games.length} games</button></div>`
+                : 'No collection loaded. Press Load collection; pricing is optional.'
+            }</td></tr>`;
         const priced = Object.keys(state.prices).length;
         const sourceErrors = Object.values(state.prices).reduce((sum, price) => sum + Object.keys(price.errors || {}).length, 0);
         elements.gameMetric.textContent = state.games.length;
         elements.pricedMetric.textContent = priced;
         elements.errorMetric.textContent = sourceErrors + Object.keys(state.failures).length;
-        elements.summary.innerHTML = `Showing <strong>${games.length}</strong> of <strong>${state.games.length}</strong> games · <strong>${priced}</strong> priced`;
+        elements.summary.innerHTML = `Showing <strong>${games.length}</strong> of <strong>${state.games.length}</strong> games · <strong>${priced}</strong> priced · ${escapeHtml(activeFilterLabel())}`;
+        elements.visibleHint.textContent = state.games.length
+          ? `${games.length} visible ${games.length === 1 ? 'game' : 'games'}; pricing runs only when requested.`
+          : 'Load a collection to begin.';
         const latest = Object.values(state.prices).map((price) => price.checkedAt).filter(Boolean).sort().pop();
         elements.lastChecked.textContent = latest ? `Last checked ${relativeTime(latest)}` : '';
         document.querySelectorAll('[data-arrow]').forEach((node) => {
@@ -567,6 +612,14 @@
         render();
       }));
       elements.rows.addEventListener('click', (event) => {
+        if (event.target.closest('[data-show-all]')) {
+          setStatusFilters({});
+          elements.search.value = '';
+          elements.amazonOnly.checked = false;
+          elements.threshold.value = '';
+          render();
+          return;
+        }
         const button = event.target.closest('[data-run-single]');
         if (!button) return;
         const id = button.dataset.runSingle;
@@ -577,6 +630,20 @@
       [elements.search, elements.threshold].forEach((input) => input.addEventListener('input', render));
       elements.amazonOnly.addEventListener('change', render);
       document.querySelectorAll('.collection-status').forEach((select) => select.addEventListener('change', render));
+      $('resetStatuses').addEventListener('click', () => {
+        setStatusFilters(STATUS_DEFAULTS);
+        render();
+      });
+      $('showAllStatuses').addEventListener('click', () => {
+        setStatusFilters({});
+        render();
+      });
+      $('clearDisplayFilters').addEventListener('click', () => {
+        elements.search.value = '';
+        elements.amazonOnly.checked = false;
+        elements.threshold.value = '';
+        render();
+      });
       elements.load.addEventListener('click', () => loadCollection(true));
       elements.username.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') loadCollection(true);
@@ -603,6 +670,7 @@
         }
       });
 
+      setStatusFilters(STATUS_DEFAULTS);
       render();
       setProgress('Ready · no API calls have run');
     })();


### PR DESCRIPTION
## What changed
- treat an empty price threshold as no filter instead of zero dollars
- reset tri-state status controls predictably on page load
- add reset/show-all recovery controls for empty result sets
- split display filters from price-run controls so batch actions remain visible
- preserve price-independent rows and per-game source selection

## Root cause
The empty threshold input was converted with `Number('')`, producing `0`. That filtered out every unpriced game even though the collection loaded successfully.

## Checks
- inline JavaScript syntax validation
- empty and whitespace threshold regression checks
- manual-only API guard
- single-source and zero-result recovery control checks