### PR TITLE
[codex] Refine BGG price grid controls

### DIFF
--- a/bgg-price-tracker.html
+++ b/bgg-price-tracker.html
@@ -17,8 +17,8 @@
     button,input,select { font:inherit }
     button { color:inherit }
     a { color:inherit; text-decoration:none }
-    .topbar { min-height:72px; display:flex; align-items:center; gap:18px; padding:14px 20px; border-bottom:1px solid var(--line); background:linear-gradient(180deg,#0b1828,#081422) }
-    .topbar,.status-panel,.progress-wrap,.toolbar,.summary { flex:0 0 auto }
+    .topbar { min-height:72px; display:flex; align-items:center; gap:12px; padding:10px 14px; overflow-x:auto; border-bottom:1px solid var(--line); background:linear-gradient(180deg,#0b1828,#081422) }
+    .topbar,.progress-wrap,.toolbar,.summary { flex:0 0 auto }
     .brand { font-size:23px; font-weight:850; letter-spacing:-.04em; white-space:nowrap }
     .brand span { color:var(--green) }
     .username { display:flex; align-items:center; gap:8px; min-width:0 }
@@ -35,13 +35,10 @@
     .btn-primary { background:var(--green); color:#042015; border-color:var(--green) }
     .btn-primary:hover { background:#54df96; border-color:#54df96 }
     .btn-small { height:30px; padding:0 9px; font-size:12px }
-    .status-panel { padding:11px 20px 12px; border-bottom:1px solid var(--line); background:#0a1726 }
-    .panel-title { display:flex; align-items:center; gap:10px; margin-bottom:8px; font-size:12px; font-weight:800; letter-spacing:.06em; text-transform:uppercase }
-    .panel-title span { color:var(--muted); font-size:11px; font-weight:500; letter-spacing:0; text-transform:none }
-    .status-grid { display:grid; grid-template-columns:repeat(8,minmax(112px,1fr)); gap:8px }
-    .status-control { display:flex; align-items:center; gap:7px; min-width:0 }
-    .status-control label { flex:1; min-width:0; overflow:hidden; color:#b9c9d8; font-size:11px; text-overflow:ellipsis; white-space:nowrap }
-    .status-control select { width:64px; height:32px; padding:0 6px }
+    .top-filters { display:flex; align-items:center; gap:7px; white-space:nowrap }
+    .top-filter { display:flex; align-items:center; gap:4px; color:#a9bdd0; font-size:10px; font-weight:700 }
+    .top-filter select { width:58px; height:32px; padding:0 5px; font-size:11px }
+    .top-filter.priority select { width:64px }
     .progress-wrap { height:31px; display:flex; align-items:center; gap:10px; padding:0 20px; border-bottom:1px solid #15283c; background:#091626 }
     .progress-track { height:4px; flex:1; background:#182c42; border-radius:999px; overflow:hidden }
     .progress-bar { width:0; height:100%; background:var(--green); transition:width .25s ease }
@@ -59,13 +56,13 @@
     .summary strong { color:var(--text) }
     .summary .error-summary { color:var(--red) }
     .table-shell { flex:1; min-height:0; overflow:auto; scrollbar-color:#28435e #091523 }
-    table { width:100%; min-width:1960px; border-collapse:separate; border-spacing:0; font-size:12px }
+    table { width:100%; min-width:1540px; border-collapse:separate; border-spacing:0; font-size:12px }
     th { position:sticky; top:0; z-index:5; height:48px; padding:7px 10px; text-align:left; color:#afc1d2; background:#0d1d2f; border-right:1px solid var(--line); border-bottom:1px solid #2a4057; white-space:nowrap }
     th button { width:100%; display:flex; align-items:center; gap:5px; border:0; padding:0; color:inherit; background:transparent; cursor:pointer; font-size:11px; font-weight:800; letter-spacing:.055em; text-transform:uppercase }
     th button:hover { color:#fff }
     th.game-head,td.game-cell { position:sticky; left:0; z-index:4 }
     th.game-head { z-index:7; min-width:270px }
-    td { height:66px; padding:7px 10px; border-right:1px solid #172a3e; border-bottom:1px solid #172a3e; background:#091725; white-space:nowrap; vertical-align:middle }
+    td { min-height:72px; padding:8px 10px; border-right:1px solid #172a3e; border-bottom:1px solid #172a3e; background:#091725; white-space:nowrap; vertical-align:middle }
     tbody tr:hover td { background:#0d1d2d }
     tbody tr:hover td.game-cell { background:#0d1d2d }
     td.game-cell { min-width:270px; background:#0a1928 }
@@ -81,7 +78,12 @@
     .source-error { max-width:120px; color:var(--red); overflow:hidden; text-overflow:ellipsis }
     .empty { color:#51677c }
     .row-actions { display:flex; align-items:center; gap:6px }
-    .single-source { width:112px; height:30px; padding:0 7px; font-size:11px }
+    .source-column { min-width:205px; width:205px }
+    .source-box { display:grid; grid-template-columns:1fr auto; align-items:center; gap:7px; min-height:54px }
+    .source-main { min-width:0 }
+    .source-meta { max-width:155px; margin-top:3px; color:var(--muted); font-size:10px; overflow:hidden; text-overflow:ellipsis }
+    .source-run { width:46px; padding:0 6px }
+    .all-run { min-width:74px }
     .status-dot { display:inline-block; width:7px; height:7px; margin-right:5px; border-radius:50%; background:var(--green) }
     .loading-dot { animation:pulse 1s ease-in-out infinite; background:var(--amber) }
     @keyframes pulse { 50% { opacity:.25 } }
@@ -109,6 +111,19 @@
       <input id="username" class="control" value="sportomax" aria-label="BGG username">
       <button id="loadButton" class="btn btn-primary">Load collection</button>
     </div>
+    <div class="top-filters" aria-label="BGG collection display filters">
+      <label class="top-filter">Own<select id="status-own" class="control collection-status" data-param="own"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Wish<select id="status-wishlist" class="control collection-status" data-param="wishlist"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <label class="top-filter priority">Priority<select id="status-wishlistpriority" class="control collection-status" data-param="wishlistpriority"><option value="">Any</option><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option><option value="5">5</option></select></label>
+      <label class="top-filter">Want<select id="status-want" class="control collection-status" data-param="want"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Play<select id="status-wanttoplay" class="control collection-status" data-param="wanttoplay"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Buy<select id="status-wanttobuy" class="control collection-status" data-param="wanttobuy"><option value="">Any</option><option value="1" selected>1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Preorder<select id="status-preordered" class="control collection-status" data-param="preordered"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Trade<select id="status-trade" class="control collection-status" data-param="fortrade"><option value="">Any</option><option value="1" selected>1</option><option value="0">0</option></select></label>
+      <label class="top-filter">Prev<select id="status-prevowned" class="control collection-status" data-param="prevowned"><option value="">Any</option><option value="1">1</option><option value="0">0</option></select></label>
+      <button id="resetStatuses" class="btn btn-small">Reset</button>
+      <button id="showAllStatuses" class="btn btn-small">All</button>
+    </div>
     <div class="grow"></div>
     <div class="metrics">
       <div class="metric"><strong id="gameMetric">0</strong><span>Games</span></div>
@@ -116,26 +131,6 @@
       <div class="metric"><strong id="errorMetric">0</strong><span>Errors</span></div>
     </div>
   </header>
-
-  <section class="status-panel" aria-label="BGG collection status filters">
-    <div class="panel-title">
-      Display filters
-      <span>The full collection stays loaded. On statuses combine as OR; Off excludes; Any ignores.</span>
-      <span class="grow"></span>
-      <button id="resetStatuses" class="btn btn-small">Reset defaults</button>
-      <button id="showAllStatuses" class="btn btn-small">Show all statuses</button>
-    </div>
-    <div class="status-grid">
-      <div class="status-control"><label for="status-own">Owned</label><select id="status-own" class="control collection-status" data-param="own"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-wishlist">Wishlist</label><select id="status-wishlist" class="control collection-status" data-param="wishlist"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-want">Want</label><select id="status-want" class="control collection-status" data-param="want"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-wanttoplay">Want to Play</label><select id="status-wanttoplay" class="control collection-status" data-param="wanttoplay"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-wanttobuy">Want to Buy</label><select id="status-wanttobuy" class="control collection-status" data-param="wanttobuy"><option value="">Any</option><option value="1" selected>On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-preordered">Preordered</label><select id="status-preordered" class="control collection-status" data-param="preordered"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-trade">For Trade</label><select id="status-trade" class="control collection-status" data-param="fortrade"><option value="">Any</option><option value="1" selected>On</option><option value="0">Off</option></select></div>
-      <div class="status-control"><label for="status-prevowned">Previously Owned</label><select id="status-prevowned" class="control collection-status" data-param="prevowned"><option value="">Any</option><option value="1">On</option><option value="0">Off</option></select></div>
-    </div>
-  </section>
 
   <div class="progress-wrap">
     <div id="progressLabel" class="progress-label">Ready</div>
@@ -178,24 +173,21 @@
       <thead>
         <tr>
           <th class="game-head"><button data-sort="name">Game <span data-arrow="name"></span></button></th>
-          <th><button data-sort="bggId">BGG ID <span data-arrow="bggId"></span></button></th>
           <th><button data-sort="year">Year <span data-arrow="year"></span></button></th>
           <th><button data-sort="average">BGG avg <span data-arrow="average"></span></button></th>
           <th><button data-sort="myRating">My rating <span data-arrow="myRating"></span></button></th>
           <th><button data-sort="plays">Plays <span data-arrow="plays"></span></button></th>
-          <th><button data-sort="amazon">Amazon <span data-arrow="amazon"></span></button></th>
-          <th>Vendor min</th><th>Vendor avg</th><th>Vendor max</th><th>Vendors</th><th>Cheapest vendor</th>
-          <th><button data-sort="ebay">eBay min <span data-arrow="ebay"></span></button></th>
-          <th>eBay avg</th><th>eBay max</th><th>eBay count</th>
-          <th><button data-sort="geekmarket">GeekMarket min <span data-arrow="geekmarket"></span></button></th>
-          <th>GM avg</th><th>GM max</th><th>GM count</th><th>Condition</th><th>Seller</th>
+          <th class="source-column"><button data-sort="amazon">Amazon <span data-arrow="amazon"></span></button></th>
+          <th class="source-column">Other vendors</th>
+          <th class="source-column"><button data-sort="ebay">eBay <span data-arrow="ebay"></span></button></th>
+          <th class="source-column"><button data-sort="geekmarket">GeekMarket <span data-arrow="geekmarket"></span></button></th>
           <th><button data-sort="best">Best deal <span data-arrow="best"></span></button></th>
           <th><button data-sort="checkedAt">Last checked <span data-arrow="checkedAt"></span></button></th>
-          <th>Action</th>
+          <th>All sources</th>
         </tr>
       </thead>
       <tbody id="rows">
-        <tr><td class="game-cell muted" colspan="25">Choose collection filters, then press Load collection.</td></tr>
+        <tr><td class="game-cell muted" colspan="12">Choose collection filters, then press Load collection.</td></tr>
       </tbody>
     </table>
   </main>
@@ -222,7 +214,7 @@
       const COLLECTION_TTL = 12 * 60 * 60 * 1000;
       const PRICE_TTL = 6 * 60 * 60 * 1000;
       const state = {
-        games: [], prices: {}, loading: new Set(), failures: {},
+        games: [], prices: {}, loading: new Set(), loadingSources: {}, failures: {},
         sortKey: 'name', sortDirection: 1, bulkRunning: false
       };
       const $ = (id) => document.getElementById(id);
@@ -237,7 +229,7 @@
         debugOutput: $('debugOutput'), toast: $('toast'), visibleHint: $('visibleHint')
       };
       const STATUS_DEFAULTS = {
-        own:'', wishlist:'', want:'', wanttoplay:'', wanttobuy:'1',
+        own:'', wishlist:'', wishlistpriority:'', want:'', wanttoplay:'', wanttobuy:'1',
         preordered:'', fortrade:'1', prevowned:''
       };
 
@@ -299,12 +291,16 @@
         const labels = {
           own:'Owned', wishlist:'Wishlist', want:'Want', wanttoplay:'Want to Play',
           wanttobuy:'Want to Buy', preordered:'Preordered', fortrade:'For Trade',
-          prevowned:'Previously Owned'
+          prevowned:'Previously Owned', wishlistpriority:'Wishlist Priority'
         };
         const filters = collectionFilters();
-        const on = Object.entries(filters).filter(([, value]) => value === '1').map(([name]) => labels[name]);
-        const off = Object.entries(filters).filter(([, value]) => value === '0').map(([name]) => `not ${labels[name]}`);
-        return [...on, ...off].join(', ') || 'All statuses';
+        const priority = filters.wishlistpriority
+          ? [`Wishlist Priority ${filters.wishlistpriority}`]
+          : [];
+        const statuses = Object.entries(filters).filter(([name]) => name !== 'wishlistpriority');
+        const on = statuses.filter(([, value]) => value === '1').map(([name]) => labels[name]);
+        const off = statuses.filter(([, value]) => value === '0').map(([name]) => `not ${labels[name]}`);
+        return [...on, ...off, ...priority].join(', ') || 'All statuses';
       };
 
       function parseCollection(xml) {
@@ -320,10 +316,13 @@
           image: text(item, 'image'),
           statuses: (() => {
             const status = item.querySelector('status');
-            return Object.fromEntries(
+            return {
+              ...Object.fromEntries(
               ['own','wishlist','want','wanttoplay','wanttobuy','preordered','fortrade','prevowned']
                 .map((name) => [name, status?.getAttribute(name) === '1'])
-            );
+              ),
+              wishlistpriority: number(status?.getAttribute('wishlistpriority'))
+            };
           })(),
           myRating: valueAttr(item, 'stats rating') === -1 ? null : valueAttr(item, 'stats rating'),
           average: valueAttr(item, 'stats rating average'),
@@ -383,7 +382,7 @@
           toast(`${games.length} games loaded for ${username}`);
         } catch (error) {
           setProgress('Collection failed');
-          elements.rows.innerHTML = `<tr><td class="game-cell source-error" colspan="25">${escapeHtml(error.message)}</td></tr>`;
+          elements.rows.innerHTML = `<tr><td class="game-cell source-error" colspan="12">${escapeHtml(error.message)}</td></tr>`;
           toast(`Collection error: ${error.message}`);
         } finally {
           elements.load.disabled = false;
@@ -428,6 +427,7 @@
         }
         if (state.loading.has(id)) return;
         state.loading.add(id);
+        state.loadingSources[id] = new Set(sources);
         delete state.failures[id];
         render();
         try {
@@ -442,6 +442,7 @@
           state.failures[id] = error.message;
         } finally {
           state.loading.delete(id);
+          delete state.loadingSources[id];
           render();
         }
       }
@@ -488,12 +489,15 @@
         const query = elements.search.value.trim().toLowerCase();
         const threshold = number(elements.threshold.value);
         const filters = collectionFilters();
-        const required = Object.entries(filters).filter(([, value]) => value === '1').map(([name]) => name);
-        const excluded = Object.entries(filters).filter(([, value]) => value === '0').map(([name]) => name);
+        const priority = number(filters.wishlistpriority);
+        const statusFilters = Object.entries(filters).filter(([name]) => name !== 'wishlistpriority');
+        const required = statusFilters.filter(([, value]) => value === '1').map(([name]) => name);
+        const excluded = statusFilters.filter(([, value]) => value === '0').map(([name]) => name);
         return state.games.filter((game) => {
           const price = state.prices[game.bggId];
           if (required.length && !required.some((name) => game.statuses?.[name])) return false;
           if (excluded.some((name) => game.statuses?.[name])) return false;
+          if (priority !== null && game.statuses?.wishlistpriority !== priority) return false;
           if (query && !game.name.toLowerCase().includes(query) && !game.bggId.includes(query)) return false;
           if (elements.amazonOnly.checked && price?.amazon?.price == null) return false;
           if (threshold !== null && (price?.bestOverall?.price == null || price.bestOverall.price > threshold)) return false;
@@ -516,67 +520,72 @@
         const content = `<span class="price${best ? ' best' : ''}">${money(value, currency)}</span>`;
         return url ? `<a href="${escapeHtml(url)}" target="_blank" rel="noopener">${content}</a>` : content;
       };
-      const metricCell = (value, best = false) => value === null || value === undefined
-        ? '<span class="empty">—</span>'
-        : `<span class="price${best ? ' best' : ''}">${money(value)}</span>`;
-
-      function sourceCell(price, source, type) {
-        if (state.loading.has(price?.bggId)) return '<div class="skeleton"></div>';
+      function sourceBox(game, price, source) {
+        const loading = state.loadingSources[game.bggId]?.has(source);
         const data = price?.[source];
-        if (!data) return errorFor(price, source) || '<span class="empty">—</span>';
-        if (type === 'min') return linkedPrice(data.min, data.cheapestUrl, data.currency, price.bestOverall?.source === source);
-        if (type === 'avg') return metricCell(data.avg);
-        if (type === 'max') return metricCell(data.max);
-        return escapeHtml(data[type] ?? '—');
+        const isBest = price?.bestOverall?.source === source;
+        let main = '<span class="empty">Not checked</span>';
+        let meta = 'Run this source only';
+
+        if (loading) {
+          main = '<div class="skeleton"></div>';
+          meta = 'Checking…';
+        } else if (price?.errors?.[source]) {
+          main = errorFor(price, source);
+          meta = 'Retry this source';
+        } else if (source === 'amazon' && data) {
+          main = linkedPrice(data.price, data.url, data.currency, isBest);
+          meta = data.listPrice != null
+            ? `List ${money(data.listPrice, data.currency)}${data.discountPercent != null ? ` · ${data.discountPercent}% off` : ''}`
+            : 'Amazon offer';
+        } else if (source === 'vendors' && data) {
+          main = linkedPrice(data.min, data.cheapestUrl, data.currency, isBest);
+          meta = `Avg ${money(data.avg)} · Max ${money(data.max)} · ${data.count} offers`;
+          if (data.cheapestName) meta += ` · ${data.cheapestName}`;
+        } else if (source === 'ebay' && data) {
+          main = linkedPrice(data.min, data.cheapestUrl, data.currency, isBest);
+          meta = `Avg ${money(data.avg)} · Max ${money(data.max)} · ${data.count} listings`;
+          if (data.cheapestTitle) meta += ` · ${data.cheapestTitle}`;
+        } else if (source === 'geekmarket' && data) {
+          main = linkedPrice(data.min, data.cheapestUrl, data.currency, isBest);
+          meta = `Avg ${money(data.avg)} · Max ${money(data.max)} · ${data.count} listings`;
+          if (data.cheapestSeller) meta += ` · ${data.cheapestSeller}`;
+          if (data.cheapestCondition) meta += ` · ${data.cheapestCondition}`;
+        }
+
+        const action = loading
+          ? '<span class="muted">Wait</span>'
+          : `<button class="btn btn-small source-run" data-run-source="${game.bggId}" data-source="${source}"${state.loading.has(game.bggId) ? ' disabled' : ''}>Run</button>`;
+        return `<div class="source-box"><div class="source-main">${main}<div class="source-meta" title="${escapeHtml(meta)}">${escapeHtml(meta)}</div></div>${action}</div>`;
       }
 
       function rowHtml(game) {
         const price = state.prices[game.bggId];
         const loading = state.loading.has(game.bggId);
         const failed = state.failures[game.bggId];
-        const amazonBest = price?.bestOverall?.source === 'amazon';
         const thumb = game.thumbnail
           ? `<img class="thumb" src="${escapeHtml(game.thumbnail)}" alt="" loading="lazy">`
           : '<div class="thumb"></div>';
-        const amazon = loading
-          ? '<div class="skeleton"></div>'
-          : price?.amazon
-            ? `${linkedPrice(price.amazon.price, price.amazon.url, price.amazon.currency, amazonBest)}
-               <div class="subline">${price.amazon.discountPercent ? `${price.amazon.discountPercent}% off` : 'Amazon'}</div>`
-            : errorFor(price, 'amazon') || '<span class="empty">—</span>';
         const best = price?.bestOverall
           ? `${linkedPrice(price.bestOverall.price, price.bestOverall.url, price.bestOverall.currency, true)}
              <div class="subline">${escapeHtml(price.bestOverall.source)} · ${escapeHtml(price.bestOverall.label)}</div>`
           : '<span class="empty">—</span>';
-        const status = loading
+        const runAll = loading
           ? '<span class="muted"><span class="status-dot loading-dot"></span>Checking</span>'
-          : `<select class="control single-source" data-source-for="${game.bggId}" aria-label="Price source for ${escapeHtml(game.name)}">
-               <option value="checked">Checked sources</option>
-               <option value="amazon">Amazon</option>
-               <option value="vendors">Others</option>
-               <option value="ebay">eBay</option>
-               <option value="geekmarket">Marketplace</option>
-             </select>
-             <button class="btn btn-small" data-run-single="${game.bggId}">Run</button>
+          : `<button class="btn btn-small all-run" data-run-all="${game.bggId}">Run all</button>
              ${failed ? `<div class="source-error" title="${escapeHtml(failed)}">Failed</div>` : ''}`;
         return `<tr>
           <td class="game-cell"><div class="game">${thumb}<div>
             <a class="game-name" href="https://boardgamegeek.com/boardgame/${game.bggId}" target="_blank" rel="noopener">${escapeHtml(game.name)}</a>
             <div class="game-meta">${game.minPlayers ?? '—'}–${game.maxPlayers ?? '—'} players · ${game.minPlaytime ?? '—'}–${game.maxPlaytime ?? '—'} min</div>
           </div></div></td>
-          <td class="num">${game.bggId}</td><td class="num">${game.year ?? '—'}</td>
+          <td class="num">${game.year ?? '—'}</td>
           <td class="num">${game.average?.toFixed(2) ?? '—'}</td><td class="num">${game.myRating?.toFixed(1) ?? '—'}</td><td class="num">${game.plays}</td>
-          <td>${amazon}</td>
-          <td>${sourceCell(price, 'vendors', 'min')}</td><td>${sourceCell(price, 'vendors', 'avg')}</td><td>${sourceCell(price, 'vendors', 'max')}</td>
-          <td class="num">${price?.vendors?.count ?? '—'}</td>
-          <td><div class="subline" title="${escapeHtml(price?.vendors?.cheapestName)}">${escapeHtml(price?.vendors?.cheapestName || '—')}</div></td>
-          <td>${sourceCell(price, 'ebay', 'min')}</td><td>${sourceCell(price, 'ebay', 'avg')}</td><td>${sourceCell(price, 'ebay', 'max')}</td>
-          <td class="num">${price?.ebay?.count ?? '—'}</td>
-          <td>${sourceCell(price, 'geekmarket', 'min')}</td><td>${sourceCell(price, 'geekmarket', 'avg')}</td><td>${sourceCell(price, 'geekmarket', 'max')}</td>
-          <td class="num">${price?.geekmarket?.count ?? '—'}</td>
-          <td>${escapeHtml(price?.geekmarket?.cheapestCondition || '—')}</td>
-          <td><div class="subline" title="${escapeHtml(price?.geekmarket?.cheapestSeller)}">${escapeHtml(price?.geekmarket?.cheapestSeller || '—')}${price?.geekmarket?.cheapestFeedbackPercent != null ? ` · ${price.geekmarket.cheapestFeedbackPercent}%` : ''}</div></td>
-          <td>${best}</td><td>${relativeTime(price?.checkedAt)}</td><td><div class="row-actions">${status}</div></td>
+          <td class="source-column">${sourceBox(game, price, 'amazon')}</td>
+          <td class="source-column">${sourceBox(game, price, 'vendors')}</td>
+          <td class="source-column">${sourceBox(game, price, 'ebay')}</td>
+          <td class="source-column">${sourceBox(game, price, 'geekmarket')}</td>
+          <td>${best}</td><td>${relativeTime(price?.checkedAt)}</td><td><div class="row-actions">${runAll}</div></td>
         </tr>`;
       }
 
@@ -584,7 +593,7 @@
         const games = filteredGames();
         elements.rows.innerHTML = games.length
           ? games.map(rowHtml).join('')
-          : `<tr><td class="game-cell muted" colspan="25">${
+          : `<tr><td class="game-cell muted" colspan="12">${
               state.games.length
                 ? `<div class="zero-state"><strong>No games match the current display filters.</strong><button class="btn btn-small" data-show-all>Show all ${state.games.length} games</button></div>`
                 : 'No collection loaded. Press Load collection; pricing is optional.'
@@ -620,12 +629,23 @@
           render();
           return;
         }
-        const button = event.target.closest('[data-run-single]');
-        if (!button) return;
-        const id = button.dataset.runSingle;
-        const choice = elements.rows.querySelector(`[data-source-for="${id}"]`)?.value || 'checked';
-        const sources = choice === 'checked' ? selectedPriceSources() : [choice];
-        priceOne(id, elements.forcePrices.checked, sources);
+        const sourceButton = event.target.closest('[data-run-source]');
+        if (sourceButton) {
+          priceOne(
+            sourceButton.dataset.runSource,
+            elements.forcePrices.checked,
+            [sourceButton.dataset.source]
+          );
+          return;
+        }
+        const allButton = event.target.closest('[data-run-all]');
+        if (allButton) {
+          priceOne(
+            allButton.dataset.runAll,
+            elements.forcePrices.checked,
+            ['amazon','vendors','ebay','geekmarket']
+          );
+        }
       });
       [elements.search, elements.threshold].forEach((input) => input.addEventListener('input', render));
       elements.amazonOnly.addEventListener('change', render);


### PR DESCRIPTION
## What changed
- move collection status filters into the top application header
- add exact Wishlist Priority filtering for Any or priorities 1 through 5
- remove BGG ID from the visible table
- consolidate pricing into one column each for Amazon, other vendors, eBay, and GeekMarket
- add an independent run button inside every marketplace cell
- reserve the final action column for running all four sources for one game

## Verification
- confirmed Wishlist Priority values against BGG XML API2 documentation and live collection XML
- validated inline JavaScript syntax
- verified the 12-column table structure and hidden BGG ID
- verified all four source-cell actions and the all-sources row action
- verified pricing remains manual-only